### PR TITLE
feat: make RDS instance creation idempotent

### DIFF
--- a/pkg/ec2/tag.go
+++ b/pkg/ec2/tag.go
@@ -12,9 +12,11 @@ func CreateEc2Tags(name string, customTags map[string]string) *[]types.Tag {
 		},
 	}
 	for k, v := range customTags {
+		key := k
+		val := v
 		t := types.Tag{
-			Key:   &k,
-			Value: &v,
+			Key:   &key,
+			Value: &val,
 		}
 		tags = append(tags, t)
 	}

--- a/pkg/rds/resource.go
+++ b/pkg/rds/resource.go
@@ -113,7 +113,6 @@ func (c *RdsClient) CreateRdsResourceStack(
 	if inventory != nil && inventory.RdsInstanceEndpoint == "" {
 		c.SendMessage(fmt.Sprintf("waiting for RDS instance %s to become available\n", inventory.RdsInstanceId))
 		endpoint, err := c.WaitForRdsInstance(inventory.RdsInstanceId, RdsConditionCreated)
-		fmt.Println(c.InventoryChan)
 		if endpoint != "" && c.InventoryChan != nil {
 			inventory.RdsInstanceEndpoint = endpoint
 			inventory.send(c.InventoryChan)

--- a/pkg/rds/subnet_group.go
+++ b/pkg/rds/subnet_group.go
@@ -1,25 +1,28 @@
 package rds
 
 import (
+	"errors"
 	"fmt"
 
-	awsrds "github.com/aws/aws-sdk-go-v2/service/rds"
+	aws_rds "github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/rds/types"
 )
 
 // CreateSubnetGroup creates a new subnet group for an RDS instances.  The
 // subnet group defines which subnets the RDS instance can be deployed to and
-// implicitly sets the VPC for the instance.
+// implicitly sets the VPC for the instance.  If a subnet group with with
+// matching name and tags already exists, that subnet group will be returned and
+// used in the resource stack to ensure idempotency.
 func (c *RdsClient) CreateSubnetGroup(
 	tags *[]types.Tag,
 	instanceName string,
 	subnetIds []string,
 ) (*types.DBSubnetGroup, error) {
-	svc := awsrds.NewFromConfig(*c.AwsConfig)
+	svc := aws_rds.NewFromConfig(*c.AwsConfig)
 
 	subnetGroupName := fmt.Sprintf("%s-subnet-group", instanceName)
 	subnetGroupDescription := fmt.Sprintf("database subnet group for RDS instance %s", instanceName)
-	createSubnetGroupInput := awsrds.CreateDBSubnetGroupInput{
+	createSubnetGroupInput := aws_rds.CreateDBSubnetGroupInput{
 		DBSubnetGroupName:        &subnetGroupName,
 		DBSubnetGroupDescription: &subnetGroupDescription,
 		SubnetIds:                subnetIds,
@@ -27,7 +30,18 @@ func (c *RdsClient) CreateSubnetGroup(
 	}
 	subnetGroupResp, err := svc.CreateDBSubnetGroup(c.Context, &createSubnetGroupInput)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create DB subnet group for RDS instance %s: %w", instanceName, err)
+		var alreadyExists *types.DBSubnetGroupAlreadyExistsFault
+		if errors.As(err, &alreadyExists) {
+			subnetGroup, uniqueTagsExist, err := c.checkSubnetGroupUniqueTags(subnetGroupName, tags)
+			if err != nil {
+				return nil, fmt.Errorf("failed to check for unique tags on subnet group %s that already exists: %w", subnetGroupName, err)
+			}
+			if uniqueTagsExist {
+				return subnetGroup, nil
+			}
+		} else {
+			return nil, fmt.Errorf("failed to create DB subnet group for RDS instance %s: %w", instanceName, err)
+		}
 	}
 
 	return subnetGroupResp.DBSubnetGroup, nil
@@ -39,9 +53,9 @@ func (c *RdsClient) DeleteSubnetGroup(subnetGroupName string) error {
 		return nil
 	}
 
-	svc := awsrds.NewFromConfig(*c.AwsConfig)
+	svc := aws_rds.NewFromConfig(*c.AwsConfig)
 
-	deleteSubnetGroupInput := awsrds.DeleteDBSubnetGroupInput{
+	deleteSubnetGroupInput := aws_rds.DeleteDBSubnetGroupInput{
 		DBSubnetGroupName: &subnetGroupName,
 	}
 	_, err := svc.DeleteDBSubnetGroup(c.Context, &deleteSubnetGroupInput)
@@ -50,4 +64,50 @@ func (c *RdsClient) DeleteSubnetGroup(subnetGroupName string) error {
 	}
 
 	return nil
+}
+
+// checkSubnetGroupUniqueTags checks to see if a subnet group with a matching
+// name and tags already exists.
+func (c *RdsClient) checkSubnetGroupUniqueTags(
+	subnetGroupName string,
+	tags *[]types.Tag,
+) (*types.DBSubnetGroup, bool, error) {
+	svc := aws_rds.NewFromConfig(*c.AwsConfig)
+
+	describeSubnetGroupsInput := aws_rds.DescribeDBSubnetGroupsInput{
+		DBSubnetGroupName: &subnetGroupName,
+	}
+	resp, err := svc.DescribeDBSubnetGroups(c.Context, &describeSubnetGroupsInput)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to describe subnet groups to check for unique tags: %w", err)
+	}
+
+	for _, subnetGroup := range resp.DBSubnetGroups {
+		listTagsInput := aws_rds.ListTagsForResourceInput{
+			ResourceName: subnetGroup.DBSubnetGroupArn,
+		}
+		tagsResp, err := svc.ListTagsForResource(c.Context, &listTagsInput)
+		if err != nil {
+			return nil, false, fmt.Errorf("failed to list tags for DB subnet group %s: %w", &subnetGroup.DBSubnetGroupName, err)
+		}
+		allTagsFound := true
+		for _, resourceTag := range tagsResp.TagList {
+			tagFound := false
+			for _, providedTag := range *tags {
+				if *providedTag.Key == *resourceTag.Key && *providedTag.Value == *resourceTag.Value {
+					tagFound = true
+					break
+				}
+			}
+			if !tagFound {
+				allTagsFound = false
+				break
+			}
+		}
+		if allTagsFound {
+			return &subnetGroup, true, nil
+		}
+	}
+
+	return nil, false, nil
 }

--- a/pkg/rds/tag.go
+++ b/pkg/rds/tag.go
@@ -1,6 +1,11 @@
 package rds
 
-import "github.com/aws/aws-sdk-go-v2/service/rds/types"
+import (
+	"fmt"
+
+	aws_rds "github.com/aws/aws-sdk-go-v2/service/rds"
+	"github.com/aws/aws-sdk-go-v2/service/rds/types"
+)
 
 // CreateRdsTags returns the tags for an RDS instance including a name tag and
 // any custom tags provided.
@@ -23,4 +28,41 @@ func CreateRdsTags(name string, customTags map[string]string) *[]types.Tag {
 	}
 
 	return &tags
+}
+
+// CheckUniqueTagsForResource takes a resource ARN for an RDS resource and a
+// slice of tags and checks to see if the resource has all of the provided tags.
+// It returns true if the resource has the tags or false if not.
+func (c *RdsClient) CheckUniqueTagsForResource(
+	resourceArn string,
+	tags *[]types.Tag,
+) (bool, error) {
+	svc := aws_rds.NewFromConfig(*c.AwsConfig)
+
+	listTagsInput := aws_rds.ListTagsForResourceInput{
+		ResourceName: &resourceArn,
+	}
+	tagsResp, err := svc.ListTagsForResource(c.Context, &listTagsInput)
+	if err != nil {
+		return false, fmt.Errorf("failed to list tags for RDS resource %s: %w", resourceArn, err)
+	}
+	allTagsFound := true
+	for _, resourceTag := range tagsResp.TagList {
+		tagFound := false
+		for _, providedTag := range *tags {
+			if *providedTag.Key == *resourceTag.Key && *providedTag.Value == *resourceTag.Value {
+				tagFound = true
+				break
+			}
+		}
+		if !tagFound {
+			allTagsFound = false
+			break
+		}
+	}
+	if allTagsFound {
+		return true, nil
+	}
+
+	return false, nil
 }

--- a/pkg/rds/tag.go
+++ b/pkg/rds/tag.go
@@ -13,9 +13,11 @@ func CreateRdsTags(name string, customTags map[string]string) *[]types.Tag {
 		},
 	}
 	for k, v := range customTags {
+		key := k
+		val := v
 		t := types.Tag{
-			Key:   &k,
-			Value: &v,
+			Key:   &key,
+			Value: &val,
 		}
 		tags = append(tags, t)
 	}

--- a/sample/rds-config.yaml
+++ b/sample/rds-config.yaml
@@ -12,6 +12,7 @@ dbUser: wordpress
 dbUserPassword: Ja9FZvvH6oWbIhdr
 tags:
   App: wordpress
+  UniqueId: 123
 ###########################################################
 # update following values for tenancy and client connection
 ###########################################################


### PR DESCRIPTION
This change allows the client to pass the existing inventory for incomplete resource stack creation so that it may be completed if it was interrupted mid-create.